### PR TITLE
Stop using deleted SessionAuthenticationMiddleware

### DIFF
--- a/server/src/dixit/settings.py
+++ b/server/src/dixit/settings.py
@@ -61,7 +61,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
`SessionAuthenticationMiddleware` was removed in [Django 2](https://docs.djangoproject.com/en/3.0/releases/2.0/). This middleware should not be used anymore. The server won't even start otherwise.

```
$ ./src/manage.py runserver
Watching for file changes with StatReloader
Performing system checks...

System check identified no issues (0 silenced).
May 18, 2020 - 00:54:59
Django version 3.0.4, using settings 'dixit.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/utils/module_loading.py", line 20, in import_string
    return getattr(module, class_name)
AttributeError: module 'django.contrib.auth.middleware' has no attribute 'SessionAuthenticationMiddleware'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/core/servers/basehttp.py", line 45, in get_internal_wsgi_application
    return import_string(app_path)
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/utils/module_loading.py", line 17, in import_string
    module = import_module(module_path)
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/remy.suen/code/github/dixit-online/server/src/dixit/wsgi.py", line 16, in <module>
    application = get_wsgi_application()
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/core/wsgi.py", line 13, in get_wsgi_application
    return WSGIHandler()
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/core/handlers/wsgi.py", line 127, in __init__
    self.load_middleware()
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/core/handlers/base.py", line 35, in load_middleware
    middleware = import_string(middleware_path)
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/utils/module_loading.py", line 24, in import_string
    ) from err
ImportError: Module "django.contrib.auth.middleware" does not define a "SessionAuthenticationMiddleware" attribute/class

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/utils/autoreload.py", line 53, in wrapper
    fn(*args, **kwargs)
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/core/management/commands/runserver.py", line 137, in inner_run
    handler = self.get_handler(*args, **options)
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/contrib/staticfiles/management/commands/runserver.py", line 27, in get_handler
    handler = super().get_handler(*args, **options)
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/core/management/commands/runserver.py", line 64, in get_handler
    return get_internal_wsgi_application()
  File "/Users/remy.suen/code/github/dixit-online/server/venv/lib/python3.7/site-packages/django/core/servers/basehttp.py", line 50, in get_internal_wsgi_application
    ) from err
django.core.exceptions.ImproperlyConfigured: WSGI application 'dixit.wsgi.application' could not be loaded; Error importing module.
```